### PR TITLE
Adds twitter follow widget

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,1 @@
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/_includes/twitter.html
+++ b/_includes/twitter.html
@@ -1,0 +1,1 @@
+<a class="twitter-follow-button" href="http://twitter.com/tldr_pages" data-show-screen-name="false" data-size="large">Follow @tldr_pages</a>

--- a/css/solo.css
+++ b/css/solo.css
@@ -163,3 +163,6 @@ pre > code {
   display: inline;
 }
 
+iframe#twitter-widget-0 {
+  height: 30px !important;
+}

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ layout: default
 
 <p class="widgets">
   {% include github_stars.html %}
+  {% include twitter.html %}
   {% include gitter_im.html %}
 </p>
 


### PR DESCRIPTION
So the old twitter widgets looked somehow differently. I like the way this one looks, but the behavior is that it's text until the javascript loads, straight from their website: https://about.twitter.com/resources/buttons#follow

It's up for discussion, but it's what I could put together in the time I have today :smile: 

It should be available for preview here: www.ostera.io/tldr-pages.github.io