### PR TITLE
Update CSS links

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
     <meta name="keywords" content="man, unix, linux, osx, commands, command-line, shell, bash, zsh">
     <meta name="robots" content="noodp,noydir">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
     <link rel="stylesheet" href="assets/css/index.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:700|Inconsolata:400,700|Source+Code+Pro">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat|Inconsolata:400,700|Source+Code+Pro">
     <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico">
   </head>
   <body>
@@ -107,7 +107,7 @@
         <a href="https://github.com/tldr-pages/tldr/wiki/TLDR-clients">TLDR clients wiki page</a>.
       </p>
 
-      <h2 id="contribute">Contributing</h2>
+      <h2 id="contributing">Contributing</h2>
 
       <p>
         This repository is an ever-growing collection of examples


### PR DESCRIPTION
- Update normalize.css to v5.0.0
- Replace `Montserrat:700` with `Montserrat` as 700 is default font size