### PR TITLE
Add anchor links and group media queries

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -10,21 +10,9 @@ html {
   font: 16px/1.5 Inconsolata, monospace;
 }
 
-@media (min-width: 30rem) {
-  html {
-    font-size: 20px;
-  }
-}
-
 body {
   margin: 2rem 0 5rem;
   color: #333;
-}
-
-@media (min-width: 30rem) {
-  body {
-    margin-top: 5rem;
-  }
 }
 
 a {
@@ -50,30 +38,17 @@ h1 {
   margin-bottom: 1rem;
 }
 
-@media (min-width: 30rem) {
-  h1 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-  }
-}
-
-h1 a,
-h2 a {
-  color: inherit;
-}
-
 h2 {
   margin-top: 2rem;
   font-size: 1.25rem;
   margin-bottom: 0.75rem;
 }
 
-@media (min-width: 30rem) {
-  h2 {
-    margin-top: 2.5rem;
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-  }
+h2 a {
+  color: #555;
+  font-family: Inconsolata, monospace;
+  margin-left: -1rem;
+  visibility: hidden;
 }
 
 h3, h4, h5, h6 {
@@ -214,4 +189,31 @@ iframe#twitter-widget-0 {
   border-width: 1px 0;
   border-style: dotted;
   border-color: rgba(255,255,255,.7);
+}
+
+@media (min-width: 30rem) {
+  html {
+    font-size: 20px;
+  }
+
+  body {
+    margin-top: 5rem;
+  }
+
+  h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    margin-top: 2.5rem;
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+}
+
+@media (min-width: 40rem) {
+  h2 a {
+    visibility: visible;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     <div class="container">
-      <h1><a href="/">TLDR pages</a></h1>
+      <h1>TLDR pages</h1>
       <blockquote>Simplified and community-driven man pages</blockquote>
 
       <p class="widgets">
@@ -45,10 +45,13 @@
         have a look at the <a href="/assets/tldr-book.pdf">PDF version</a>,
         or follow the <a href="#installation">installation instructions</a>.
       </p>
-      
+
       <iframe src="https://tldr.ostera.io/tar" width="100%" height="500px" style="border: 1px solid"></iframe>
 
-      <h2 id="installation">Installation</h2>
+      <h2 id="installation">
+        <a href="#installation">§</a>
+        Installation
+      </h2>
 
       <p>As of now, our most mature client is the node.js one, which you can easily install from NPM:</p>
       <pre>npm install -g tldr</pre>
@@ -107,7 +110,10 @@
         <a href="https://github.com/tldr-pages/tldr/wiki/TLDR-clients">TLDR clients wiki page</a>.
       </p>
 
-      <h2 id="contributing">Contributing</h2>
+      <h2 id="contributing">
+        <a href="#contributing">§</a>
+        Contributing
+      </h2>
 
       <p>
         This repository is an ever-growing collection of examples
@@ -119,9 +125,15 @@
         at the <a href="https://github.com/tldr-pages/tldr">project's repository</a>
         and submit a pull request.
       </p>
-      <p>Just keep in mind the <a href="https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md">Contributing guidelines</a>.</p>
+      <p>
+        Just keep in mind the
+        <a href="https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md">Contributing guidelines</a>.
+      </p>
 
-      <h2 id="license">License</h2>
+      <h2 id="license">
+        <a href="#license">§</a>
+        License
+      </h2>
 
       <p><a href="https://github.com/tldr-pages/tldr/blob/master/LICENSE.md">MIT License</a></p>
     </div>


### PR DESCRIPTION
As discussed in #17.

Key changes:
- Remove the link from `<h1>` title as it's useless (we only have one page)
- Add anchor links to `<h2>`s
- Group all media queries into one

Media queries should be grouped because it lets browsers read CSS quicker and it allows us to maintain them more easily.