### PR TITLE
Add Tealdeer

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,12 @@
           </tr>
           <tr>
             <td><a href="https://github.com/tldr-pages/tldr-cpp-client">C++ client</a></td>
-            <td>
-              <code>brew install tldr</code>
-            </td>
+            <td><code>brew install tldr</code></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/dbrgn/tealdeer/">Rust client</a></td>
+            <td><code>cargo install tealdeer</code> / <code>yaourt -S tealdeer</code></td>
+          </tr>
           <tr>
             <td><a href="https://github.com/gianasista/tldr-viewer">Android client</a></td>
             <td><a href="https://play.google.com/store/apps/details?id=de.gianasista.tldr_viewer">tldr-viewer on Google Play</a></td>


### PR DESCRIPTION
I hope I may shamelessly ask to put Tealdeer on the tldr website...

It's quite mature by now, so I released version 1.0.0 yesterday. It supports caching, conforms to the XDG basedir specification for cached files, implements both the old and the new tldr-pages format, uses almost the same command line API as the NodeJS client and it's the fastest of all clients I tested: https://github.com/dbrgn/tealdeer/#goals

There is a package for Arch Linux, otherwise users currently need to use cargo to install the package. But binary releases are planned.

(I'm not sure if there is some kind of sorting system in the table, I just put it after the C++ client (which should be renamed C client because it doesn't use C++ anymore)).