### PR TITLE
Show official Python client

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,8 @@
             <td><code>cpanm App::tldr</code></td>
           </tr>
           <tr>
-            <td><a href="https://github.com/lord63/tldr.py">Python client</a></td>
-            <td><code>pip install tldr.py</code></td>
+            <td><a href="https://github.com/tldr-pages/tldr-python-client">Python client</a></td>
+            <td><code>pip install tldr</code></td>
           </tr>
           <tr>
             <td><a href="https://github.com/tldr-pages/tldr-cpp-client">C++ client</a></td>


### PR DESCRIPTION
No offense to lord63, but official Python client is just better and it is not listed on the site. I thought I needed to use tldr.py, which [requires reading manual](https://github.com/lord63/tldr.py/issues/35) to use.  

I have installed official one only because I googled it.