### PR TITLE
Move `pacman -S tldr` to Python client from C++

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,11 +88,11 @@
           </tr>
           <tr>
             <td><a href="https://github.com/tldr-pages/tldr-python-client">Python client</a></td>
-            <td><code>pip install tldr</code></td>
+            <td><code>pip install tldr</code> / <code>pacman -S tldr</code></td>
           </tr>
           <tr>
             <td><a href="https://github.com/tldr-pages/tldr-cpp-client">C++ client</a></td>
-            <td><code>brew install tldr</code> / <code>pacman -S tldr</code></td>
+            <td><code>brew install tldr</code></td>
           </tr>
           <tr>
             <td><a href="https://github.com/dbrgn/tealdeer/">Rust client</a></td>


### PR DESCRIPTION
Small thing but based on the [tldr package on Arch's community packages](https://www.archlinux.org/packages/community/any/tldr/), this is grabbing the python client and not the C++ one as is currently listed