### PR TITLE
remove android client

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,10 +93,6 @@
             <td><code>cargo install tealdeer</code> / <code>yaourt -S tealdeer</code></td>
           </tr>
           <tr>
-            <td><a href="https://github.com/gianasista/tldr-viewer">Android client</a></td>
-            <td><a href="https://play.google.com/store/apps/details?id=de.gianasista.tldr_viewer">tldr-viewer on Google Play</a></td>
-          </tr>
-          <tr>
             <td><a href="https://github.com/freesuraj/TLDR">iOS client</a></td>
             <td><a href="https://appsto.re/sg/IQ0-_.i">TLDR Man Page on App Store</a></td>
           </tr>


### PR DESCRIPTION
Hi,
This PR removes the [Android client](https://play.google.com/store/apps/details?id=de.gianasista.tldr_viewer) as it is no longer available on the Google Play Store. 
We could change this to another client like [tldroid](https://play.google.com/store/apps/details?id=io.github.hidroh.tldroid), but since the [project](https://github.com/hidroh/tldroid) isn't being updated since 2017 I decided not to. Should we go with this or do you guys prefer to link this other client? 