### PR TITLE
Add master to main branch mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,14 @@
+name: Main Mirror
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: zofrex/mirror-branch@v1
+        with:
+          target-branch: main

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,7 +2,7 @@ name: Main Mirror
 
 on:
   push:
-    branches: ['master']
+    branches: [master]
 
 jobs:
   mirror:


### PR DESCRIPTION
Part of work for https://github.com/tldr-pages/tldr/issues/5110. This adds a new workflow here that mirrors any pushes to master to the main branch. This sets up the mirror from `master` to `main`, which will exist for some time to just ensure that the infrastructure is in place so that once `main` becomes the default branch, this workflow would be reversed and leave `master` operational giving clients time to migrate while we use `main`.

Once this is ready to be merged, a `main` branch should be created, then this PR merged.