### PR TITLE
index.html: fix link to Clients wiki page

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           <li>web-based clients</li>
           <li>clients which integrate with other applications</li>
         </ul>
-        They can be found <a href="https://github.com/tldr-pages/tldr/wiki/tldr-pages-clients">in the wiki.</a>
+        They can be found <a href="https://github.com/tldr-pages/tldr/wiki/Clients">in the wiki.</a>
       </p>
 
       <h2 id="contributing">


### PR DESCRIPTION
The wiki page "tldr-pages-clients" doesn't exist (anymore?).